### PR TITLE
Allow selecting more than 2 modules and recursively merge child modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@ Intellij plugin: Maven toolkit
 =======================
 
 
-This plugin just allow to merge 2 maven module.
+This plugin allows merging 2 or more maven modules.
 
 Usage
 ------
-* select 2 modules
+* select 2 or more modules
 * right click
 * click on maven > merge modules
 
-This will merge the first selected modules in the second one. It also handle the update of dependencies.
+This will merge all selected modules. It also handle the update of dependencies.
 
 In addition you can also merge a child project into its parent.
 
@@ -24,4 +24,4 @@ Some ideas for future features:
 
 * merge dialog when drag-n-droping a module into an other
 * add action do move module correctly
-* add a rename action that update dependencies 
+* add a rename action that update dependencies

--- a/src/main/kotlin/com/bmesta/mvntoolkit/action/MergeModules.kt
+++ b/src/main/kotlin/com/bmesta/mvntoolkit/action/MergeModules.kt
@@ -26,7 +26,7 @@ import com.intellij.refactoring.actions.BaseRefactoringAction
  */
 class MergeModules() : BaseRefactoringAction() {
     override fun isEnabledOnElements(elements: Array<out PsiElement>): Boolean {
-        return elements.size == 2
+        return elements.size > 1
     }
 
     override fun getHandler(p0: DataContext): RefactoringActionHandler? {

--- a/src/main/kotlin/com/bmesta/mvntoolkit/action/MergeModulesHandler.kt
+++ b/src/main/kotlin/com/bmesta/mvntoolkit/action/MergeModulesHandler.kt
@@ -42,14 +42,12 @@ class MergeModulesHandler : RefactoringActionHandler {
     override fun invoke(project: Project, elements: Array<out PsiElement>, context: DataContext?) {
 
         val mavenProjects = MavenActionUtil.getMavenProjects(context)
-        val from = mavenProjects[0]
-        val into = mavenProjects[1]
-        if (from != null && into != null) {
+        if (mavenProjects.none { it == null }) {
             if (showRefactoringDialog()) {
                 CommandProcessor.getInstance().executeCommand(project, {
                     val action = {
                         try {
-                            doRefactoring(project, from, into)
+                            doRefactoring(project, mavenProjects)
                         } catch (var2: IncorrectOperationException) {
                             LOG.error(var2)
                         }
@@ -61,10 +59,10 @@ class MergeModulesHandler : RefactoringActionHandler {
 
     }
 
-    private fun doRefactoring(project: Project, from: MavenProject, into: MavenProject) {
+    private fun doRefactoring(project: Project, mavenProjects: List<MavenProject>) {
 
         PsiDocumentManager.getInstance(project).commitAllDocuments()
-        ModulesMergerTask(project, from, into).queue()
+        ModulesMergerTask(project, mavenProjects).queue()
 
         PsiDocumentManager.getInstance(project).commitAllDocuments()
     }

--- a/src/main/kotlin/com/bmesta/mvntoolkit/action/ModulesMergerTask.kt
+++ b/src/main/kotlin/com/bmesta/mvntoolkit/action/ModulesMergerTask.kt
@@ -24,10 +24,10 @@ import org.jetbrains.idea.maven.project.MavenProject
 /**
  * @author Baptiste Mesta
  */
-class ModulesMergerTask(project: Project, val from: MavenProject, val into: MavenProject) : Task.Backgroundable(project, "Merging modules...") {
+class ModulesMergerTask(project: Project, val mavenProjects: List<MavenProject>) : Task.Backgroundable(project, "Merging modules...") {
     override fun run(progressIndicator: ProgressIndicator) {
 
-        ModulesMerger(project, from, into).merge(progressIndicator)
+        ModulesMerger(project, progressIndicator).merge(mavenProjects)
 
     }
 }


### PR DESCRIPTION
@baptistemesta I don't know if this is a feature you are interested in, but I figured I would see what you think.

We have a Maven project we are re-organizing that has quite a few modules, many of which are nested. Your plugin works great, but it's tedious to merge 2 at a time, and child modules have to be merged first or else they are deleted.

With these changes, I was able to merge everything at once. [cloc](https://www.npmjs.com/package/cloc) showed that I still had the same number of Java files and #loc, so it seems to have worked properly, though I have not tested it any further yet.